### PR TITLE
v1.7.3 CRF 미세조정, 정렬 옵션 추가

### DIFF
--- a/src/py_media_compressor/entry/encode.py
+++ b/src/py_media_compressor/entry/encode.py
@@ -45,8 +45,15 @@ def main():
         default="numbering",
         help="출력 폴더에 같은 이름의 파일이 있을 경우, 사용할 모드.",
     )
+    # parser.add_argument(
+    #     "--no_sort", dest="sort", action="store_false", help="파일크기 오름차순으로 정렬을 하지 않습니다."
+    # )
     parser.add_argument(
-        "--no_sort", dest="sort", action="store_false", help="파일크기 오름차순으로 정렬을 하지 않습니다."
+        "--sort-mode",
+        dest="sort_mode",
+        choices=["on", "reverse", "off"],
+        default="on",
+        help="파일 사이즈 정렬 옵션 (on = 내림차순, reverse = 오름차순)",
     )
     parser.add_argument(
         "-s",
@@ -200,8 +207,11 @@ def main():
         isSizeSkip=args["size_skip"],
     )
 
-    if args.get("sort", True):
+    sort_mode = args.get("sort_mode", "on").lower()
+    if sort_mode == "on":
         file_infos.sort(key=lambda fi: fi.input_filesize)
+    elif sort_mode == "reverse":
+        file_infos.sort(key=lambda fi: fi.input_filesize, reverse=True)
 
     ffmpeg_args: model.FFmpegArgs
     for file_info in (file_info_tqdm := tqdm(file_infos, leave=False, dynamic_ncols=True)):

--- a/src/py_media_compressor/model/encode_option.py
+++ b/src/py_media_compressor/model/encode_option.py
@@ -45,9 +45,9 @@ class EncodeOption(DictDataBase):
 
         if crf < 0:
             if codec == "h.264":
-                crf = 23
+                crf = 19
             elif codec == "h.265":
-                crf = 28
+                crf = 21
 
         self._data = {
             "max_height": maxHeight,

--- a/src/py_media_compressor/version.py
+++ b/src/py_media_compressor/version.py
@@ -1,3 +1,3 @@
 package_name = "py_media_compressor"
-version = "1.7.2"
+version = "1.7.3"
 metadata_version = 1


### PR DESCRIPTION
- [Fix: 인코딩 옵션의 CRF 값 조정 (h.264: 23 -> 19, h.265: 28 -> 21)](https://github.com/Cardroid/PyMediaCompressor/commit/ce1cdeae9c92784a09763ba8be03bbd0563796dd)
- [Feat: 정렬 모드 옵션 추가 및 기존 정렬 방식 수정](https://github.com/Cardroid/PyMediaCompressor/commit/d3ada4201639a27315e59a6140949c3c18c7f62d)