### PR TITLE
v1.7.4 블록 현상 완화 및 문서 업데이트

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ### 설명
 
 FFmpeg를 사용하여 미디어를 인코딩합니다.  
-preset을 veryslow로 설정하여 CPU 사용량이 매우 높지만, 높은 압축률로 미디어를 인코딩할 수 있습니다.  
+느리지만 압축률이 높은 preset을 설정하여 CPU 사용량이 매우 높지만, 높은 압축률로 미디어를 인코딩할 수 있습니다.  
 해당 프로젝트는 FFmpeg를 잘 알지 못해도 사용할 수 있도록 개발되었습니다.
 
 > ubuntu 20.04 서버, windows 11 에서 테스트 되었습니다.
@@ -49,7 +49,7 @@ usage: encode [-h]
               [-r]
               [-p]
               [-e {overwrite,skip,numbering}]
-              [--no_sort]
+              [--sort_mode]
               [-s]
               [-f]
               [-c {h.264,h.265}]
@@ -71,7 +71,7 @@ optional arguments:
   -p, --size_skip       빠른 작업을 위해 인코딩 도중 출력파일 크기가 입력파일 크기보다 커지는 순간 즉시 건너뜁니다.
   -e {overwrite,skip,numbering}, --already_exists_mode {overwrite,skip,numbering}
                         출력 폴더에 같은 이름의 파일이 있을 경우, 사용할 모드.
-  --no_sort             파일크기 오름차순으로 정렬을 하지 않습니다.
+  --sort_mode           파일 사이즈 정렬 옵션 (on = 내림차순, reverse = 오름차순)
   -s, --save_error_output
                         오류가 발생한 출력물을 제거하지 않습니다.
   -f, --force           이미 압축된 미디어 파일을 강제로, 재압축합니다.

--- a/src/py_media_compressor/encoder/args_builder.py
+++ b/src/py_media_compressor/encoder/args_builder.py
@@ -90,7 +90,7 @@ def add_video_args(ffmpegArgs: FFmpegArgs):
         elif compression_mode == "h.265":
             ffmpegArgs["c:v"] = "libx265"
         ffmpegArgs["crf"] = ffmpegArgs.encode_option.crf
-        ffmpegArgs["preset"] = "veryslow"
+        ffmpegArgs["preset"] = "slower"
 
         # 세로 또는 가로 픽셀 수가 짝수가 아닐 경우 발생하는 오류 처리 포함
         if (width := ffmpegArgs.video_stream.get("width")) is None:

--- a/src/py_media_compressor/entry/encode.py
+++ b/src/py_media_compressor/entry/encode.py
@@ -49,7 +49,7 @@ def main():
     #     "--no_sort", dest="sort", action="store_false", help="파일크기 오름차순으로 정렬을 하지 않습니다."
     # )
     parser.add_argument(
-        "--sort-mode",
+        "--sort_mode",
         dest="sort_mode",
         choices=["on", "reverse", "off"],
         default="on",

--- a/src/py_media_compressor/model/encode_option.py
+++ b/src/py_media_compressor/model/encode_option.py
@@ -45,9 +45,9 @@ class EncodeOption(DictDataBase):
 
         if crf < 0:
             if codec == "h.264":
-                crf = 19
+                crf = 23
             elif codec == "h.265":
-                crf = 21
+                crf = 28
 
         self._data = {
             "max_height": maxHeight,

--- a/src/py_media_compressor/model/ffmpeg_args.py
+++ b/src/py_media_compressor/model/ffmpeg_args.py
@@ -39,6 +39,10 @@ class FFmpegArgs(DictDataExtendBase):
             elif stream["codec_type"] == "audio":
                 self._audio_streams.append(stream)
 
+        # self["-profile:v"] = "none"
+        # self["-tune:v"] = "none"
+        # self["-level:v"] = "auto"
+
     def _as_dict(self) -> Dict[str, Any]:
         result = super()._as_dict()
         result["filename"] = self.file_info.output_filepath

--- a/src/py_media_compressor/version.py
+++ b/src/py_media_compressor/version.py
@@ -1,3 +1,3 @@
 package_name = "py_media_compressor"
-version = "1.7.3"
+version = "1.7.4"
 metadata_version = 1


### PR DESCRIPTION
영상 압축률이 너무 높을 경우 블록(깍두기)현상이 발생
 - [Fix: 인코딩 옵션의 프리셋 값을 "veryslow"에서 "slower"로 변경](https://github.com/Cardroid/PyMediaCompressor/commit/7d68a88674129488de0df2991acfb9ccbb685163)

문서 업데이트 및 이전 수정 사항 복원
 - [Docs: README 옵션 추가 및 업데이트](https://github.com/Cardroid/PyMediaCompressor/commit/88ab568e6fd3f23c08497235cb1efcaecb2df502)
 - [Fix: 인코딩 옵션의 CRF 값을 h.264: 23, h.265: 28로 변경](https://github.com/Cardroid/PyMediaCompressor/commit/558ba46533473396d064ed58beae6135873f1f2b)