### PR TITLE
v1.7.5 재인코딩 감지 조건 추가, 기존 메타데이터 유지 로직 수정

### DIFF
--- a/src/py_media_compressor/encoder/args_builder.py
+++ b/src/py_media_compressor/encoder/args_builder.py
@@ -225,6 +225,8 @@ def add_metadata_args(ffmpegArgs: FFmpegArgs):
         logger.info(f"이미 처리된 미디어입니다.\nFileInfo: {ffmpegArgs.file_info}")
         if ffmpegArgs.encode_option.is_force:
             logger.warning("강제로 재인코딩을 실시합니다... (is_force)")
+        elif ffmpegArgs.encode_option.max_height > 0 and ffmpegArgs.video_stream.get("height", 0) != ffmpegArgs.encode_option.max_height:
+            logger.warning("화면 크기가 다르므로 재인코딩을 실시합니다...")
         else:
             ffmpegArgs.file_info.status = FileTaskStatus.SKIPPED
 

--- a/src/py_media_compressor/encoder/args_builder.py
+++ b/src/py_media_compressor/encoder/args_builder.py
@@ -194,10 +194,11 @@ def add_metadata_args(ffmpegArgs: FFmpegArgs):
             key, value = line.split("=")
             metadatas[key.strip().lower()] = value.strip()
     else:
-        metadatas["amcp_ver"] = version.metadata_version
         metadatas["amcp_input_filesize"] = ffmpegArgs.file_info.input_filesize
         metadatas["amcp_input_file_MD5"] = ffmpegArgs.file_info.input_file_MD5
-        metadatas["amcp_encoded_date"] = int(time())
+
+    metadatas["amcp_encoded_date"] = int(time())
+    metadatas["amcp_ver"] = version.metadata_version
 
     if len(metadatas) > 0:
         c_metadata = []

--- a/src/py_media_compressor/version.py
+++ b/src/py_media_compressor/version.py
@@ -1,3 +1,3 @@
 package_name = "py_media_compressor"
-version = "1.7.4"
+version = "1.7.5"
 metadata_version = 1


### PR DESCRIPTION
- 기존 메타데이터(입력 파일의 해시 및 크기) 유지
- 이미 인코딩된 파일도 화면 비율이 다를 경우, 자동으로 재인코딩 간주